### PR TITLE
feat(jwt-startegy): implement jwt strategy and jwt auth guard

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,41 +4,43 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-    {
-        ignores: ['eslint.config.mjs'],
+  {
+    ignores: ['eslint.config.mjs'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+      ecmaVersion: 5,
+      sourceType: 'module',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
-    eslint.configs.recommended,
-    ...tseslint.configs.recommendedTypeChecked,
-    eslintPluginPrettierRecommended,
-    {
-        languageOptions: {
-            globals: {
-                ...globals.node,
-                ...globals.jest,
-            },
-            ecmaVersion: 5,
-            sourceType: 'module',
-            parserOptions: {
-                projectService: true,
-                tsconfigRootDir: import.meta.dirname,
-            },
+  },
+  {
+    rules: {
+      '@typescript-eslint/require-await': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'warn',
+      '@typescript-eslint/no-unsafe-call': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
         },
+      ],
     },
-    {
-        rules: {
-            '@typescript-eslint/require-await': 'off',
-            '@typescript-eslint/no-explicit-any': 'off',
-            '@typescript-eslint/no-floating-promises': 'warn',
-            '@typescript-eslint/no-unsafe-argument': 'off',
-            '@typescript-eslint/no-unsafe-return': 'off',
-            '@typescript-eslint/no-unsafe-member-access': 'off',
-            '@typescript-eslint/no-unused-vars': [
-                'error',
-                {
-                    argsIgnorePattern: '^_',   
-                    varsIgnorePattern: '^_',
-                },
-            ],
-        },
-    }
+  },
 );

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -1,0 +1,3 @@
+export interface EnvConfig {
+  JWT_SECRET: string;
+}

--- a/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import type { EnvConfig } from '@config/config.schema';
+
+export interface JwtPayload {
+  sub: string;
+  email: string;
+  role: string;
+}
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(configService: ConfigService<EnvConfig>) {
+    const secret = configService.get<string>('JWT_SECRET');
+
+    if (!secret) {
+      throw new Error('JWT_SECRET is not defined in the environment configuration.');
+    }
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: secret,
+    });
+  }
+
+  async validate(payload: JwtPayload) {
+    return {
+      userId: payload.sub,
+      email: payload.email,
+      role: payload.role,
+    };
+  }
+}


### PR DESCRIPTION
✅ What Changed

- Implemented JWT authentication using a JwtAuthGuard and JwtStrategy.
- Relocated the google authentication strategy from src/auth/google to src/modules/auth/google.
- Updated all related import paths to reflect the new structure.
- Centralized all authentication strategies (Google and JWT) under the modules/auth directory.

🧠 Why It Changed

- To follow a modular architecture by grouping authentication logic under src/modules/auth.
- Improves project organization, maintainability, and scalability.
- Keeps auth-related strategies encapsulated and discoverable in a consistent location.

🔧 How It Was Implemented

- Developed JwtStrategy and JwtAuthGuard for handling JWT-based authentication.
- Moved the google folder into modules/auth/.
- Updated imports in auth.module.ts, main.ts, and any affected services/modules.
- Verified that authentication strategies are correctly registered and functional.

✅ Checklist
 

- [x] google/ folder moved to modules/auth/
- [x] JWT strategy and guard implemented
- [x] All relevant import paths updated
- [x] Auth module working as expected
- [ ] Tests updated or added (if required)
- [ ] README or architecture documentation updated (if applicable)