### PR TITLE
fix(constants): standardize ping and pong responses to lowercase

### DIFF
--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -86,8 +86,8 @@ export const API_CONSTANTS = {
   GOOGLE: 'google',
   API_GLOBAL_PREFIX: '/api/v1',
   HEALTH_CHECK: 'Health Check',
-  PING: 'Ping',
-  PONG: 'Pong!',
+  PING: 'ping',
+  PONG: 'pong!',
   PATH: '/api/v1/auth',
 };
 


### PR DESCRIPTION
Update the PING and PONG constants to use lowercase for consistency in API responses.