### PR TITLE
refactor: course retrieval in GetCourseHandler

### DIFF
--- a/src/modules/course/queries/handlers/get-course-by-id.handler.ts
+++ b/src/modules/course/queries/handlers/get-course-by-id.handler.ts
@@ -1,5 +1,5 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
-import { Prisma } from '@prisma/client';
+import { Course } from '@prisma/client';
 import { GetCourseQuery } from '../get-course-by-id.query';
 import { DatabaseService } from '@common/database/database.service';
 
@@ -7,16 +7,8 @@ import { DatabaseService } from '@common/database/database.service';
 export class GetCourseHandler implements IQueryHandler<GetCourseQuery> {
   constructor(private readonly databaseService: DatabaseService) {}
 
-  async execute(query: GetCourseQuery): Promise<Prisma.CourseGetPayload<{
-    include: {
-      lessons: {
-        include: {
-          blocks: true;
-        };
-      };
-    };
-  }> | null> {
-    return this.databaseService.course.findUnique({
+  async execute(query: GetCourseQuery): Promise<Course | null> {
+    return this.databaseService.course.findFirst({
       where: { id: query.courseId },
       include: {
         lessons: {


### PR DESCRIPTION
Simplify the course retrieval logic by changing the method from `findUnique` to `findFirst` and updating the return type accordingly.