### PR TITLE
fix: prettier configuration and add missing commas

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,9 @@
 {
   "semi": true,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 180,
   "tabWidth": 2,
-  "endOfLine": "lf",
+  "endOfLine": "auto",
   "arrowParens": "avoid"
 }

--- a/src/modules/block/block.controller.ts
+++ b/src/modules/block/block.controller.ts
@@ -10,7 +10,7 @@ import { DeleteBlockCommand } from './commands/delete-block.command';
 export class BlocksController {
   constructor(
     private readonly commandBus: CommandBus,
-    private readonly queryBus: QueryBus
+    private readonly queryBus: QueryBus,
   ) {}
 
   @Get()

--- a/src/modules/lesson/commands/update-lesson.command.ts
+++ b/src/modules/lesson/commands/update-lesson.command.ts
@@ -4,6 +4,6 @@ export class UpdateLessonCommand {
     public readonly data: {
       title?: string;
     },
-    public readonly userId: string
+    public readonly userId: string,
   ) {}
 }

--- a/src/modules/lesson/lesson.controller.ts
+++ b/src/modules/lesson/lesson.controller.ts
@@ -15,7 +15,7 @@ import { Lesson } from '@prisma/client';
 export class LessonsController {
   constructor(
     private readonly commandBus: CommandBus,
-    private readonly queryBus: QueryBus
+    private readonly queryBus: QueryBus,
   ) {}
 
   @Get()


### PR DESCRIPTION
Correct trailingComma and endOfLine settings in the .prettierrc file, and ensure consistent use of commas in TypeScript class constructors.