### PR TITLE
feat: added authorization to create lessons endpoint

### DIFF
--- a/src/modules/lesson/commands/create-lesson.command.ts
+++ b/src/modules/lesson/commands/create-lesson.command.ts
@@ -1,5 +1,8 @@
 import { CreateLessonDto } from '../dto/create-lesson.dto';
 
 export class CreateLessonCommand {
-  constructor(public readonly createLessonRequest: CreateLessonDto) {}
+  constructor(
+    public readonly createLessonRequest: CreateLessonDto,
+    public readonly userId: string,
+  ) {}
 }

--- a/src/modules/lesson/commands/handlers/create-lesson.handler.ts
+++ b/src/modules/lesson/commands/handlers/create-lesson.handler.ts
@@ -2,13 +2,43 @@ import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { Lesson } from '@prisma/client';
 import { CreateLessonCommand } from '../create-lesson.command';
 import { DatabaseService } from '@common/database/database.service';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 
 @CommandHandler(CreateLessonCommand)
 export class CreateLessonHandler implements ICommandHandler<CreateLessonCommand> {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async execute(command: CreateLessonCommand): Promise<Lesson> {
-    const { createLessonRequest } = command;
+    const { createLessonRequest, userId } = command;
+    const { order, courseId } = createLessonRequest;
+
+    const course = await this.databaseService.course.findUnique({
+      where: { id: courseId },
+    });
+
+    // Ensure the course is valid
+    if (!course) {
+      throw new NotFoundException('Course not found');
+    }
+
+    // Ensure the user is the owner of the course
+    if (course.authorId !== userId) {
+      throw new ForbiddenException('You are not allowed to create lessons for this course');
+    }
+
+    // Increase the order of other lessons after this lesson
+    await this.databaseService.lesson.updateMany({
+      where: {
+        courseId,
+        order: { gte: order },
+      },
+      data: {
+        order: {
+          increment: 1,
+        },
+      },
+    });
+
     return this.databaseService.lesson.create({
       data: {
         ...createLessonRequest,

--- a/src/modules/lesson/lesson.controller.ts
+++ b/src/modules/lesson/lesson.controller.ts
@@ -24,8 +24,11 @@ export class LessonsController {
   }
 
   @Post()
-  async createLesson(@Body() createLessonDto: CreateLessonDto) {
-    return this.commandBus.execute(new CreateLessonCommand(createLessonDto));
+  async createLesson(@Body() createLessonDto: CreateLessonDto, @CurrentUser('userId') userId: string) {
+    if (!userId) {
+      throw new Error('Author ID is missing from token');
+    }
+    return this.commandBus.execute(new CreateLessonCommand(createLessonDto, userId));
   }
 
   @Get(':id')


### PR DESCRIPTION
- Added validation for "create lesson" endpoint
- Ensure users can create lessons in only their course
- Ensured that the other lessons in the course are reordered in accordance to the `order` of the created lesson